### PR TITLE
Remove unit for trend 06.json Women Candidates

### DIFF
--- a/homepage-trends/06.json
+++ b/homepage-trends/06.json
@@ -1,6 +1,5 @@
 {
   "chartConfig": {
-    "legendUnit": "k",
     "legendTitle": "Women Candidates",    
     "range": [
       "#e0d9ce",


### PR DESCRIPTION
The "Women Candidates" trend legend does not need the "k" unit - the numbers represent actual values.